### PR TITLE
chore(ci): add GitHub Actions workflow to enforce Conventional Commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,13 @@
+name: Conventional Commits
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+    name: Conventional Commits
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: webiny/action-conventional-commits@v1.3.0


### PR DESCRIPTION
This PR introduces a GitHub Actions workflow (`main.yml`) under `.github/workflows` that enforces the use of [Conventional Commits](https://www.conventionalcommits.org/) on all pull requests targeting the master branch.